### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a **laboratory instrumentation codebase** (Breuer Lab, Brown University) for wind tunnel aerodynamics research. It is primarily MATLAB-based with two embedded firmware components that can be built in a cloud environment.
+
+### Buildable components (no hardware required)
+
+| Component | Path | Tool | Build command |
+|-----------|------|------|---------------|
+| ESP32 firmware (Calimero) | `Calimero/ESP32/` | PlatformIO | `pio run` (from that directory) |
+| TriggerBox v2.6 | `TriggerBox/TriggerBox_v2.6/` | Arduino CLI | `arduino-cli compile --fqbn arduino:avr:uno TriggerBox/TriggerBox_v2.6/TriggerBox_v2.6.ino` |
+
+### Lint/static analysis
+
+- **ESP32 (PlatformIO):** `cd Calimero/ESP32 && pio check --skip-packages`
+- **Arduino sketches:** compilation itself serves as the lint step (`arduino-cli compile`)
+
+### Known pre-existing issues
+
+- `Calimero/ESP32/src/main.cpp` line 76 has a missing semicolon — `pio run` will fail until fixed.
+- `TriggerBox/TriggerBox2.0/TriggerBox2.0.ino` has pre-existing syntax errors.
+- `TriggerBox/TriggerBox_v2.6/TriggerBox_v2.6.ino` compiles cleanly.
+
+### What cannot run in a cloud environment
+
+The MATLAB scripts (majority of the repo) require:
+- MATLAB with Data Acquisition Toolbox
+- Physical hardware (NI-DAQ, ATI load cells, Galil DMC controllers, Kollmorgen servo drives)
+- Vendor drivers (NI-DAQmx, Galil ActiveX toolkit)
+
+These are inherently hardware-dependent and cannot be tested without lab equipment.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development instructions for this laboratory instrumentation codebase.

## What this enables

This codebase is primarily MATLAB-based for lab hardware control, but has two embedded firmware components that can be built in a cloud environment:

| Component | Tool | Status |
|-----------|------|--------|
| ESP32 firmware (Calimero) | PlatformIO CLI | Lint passes; build fails due to pre-existing syntax error on line 76 |
| TriggerBox v2.6 (Arduino) | Arduino CLI | Compiles successfully |

## Verification

[final_verification.log](https://cursor.com/agents/bc-b55f1d21-35b3-401a-aa58-9c088f7afded/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffinal_verification.log)

## Changes

- Added `AGENTS.md` documenting buildable components, lint commands, known pre-existing issues, and hardware-only limitations.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b55f1d21-35b3-401a-aa58-9c088f7afded"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b55f1d21-35b3-401a-aa58-9c088f7afded"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

