### PR TITLE
Average all wake force struct fields

### DIFF
--- a/Calimero/Flow Visualization/STB Processing/phase averaging/phase_avg_STB.m
+++ b/Calimero/Flow Visualization/STB Processing/phase averaging/phase_avg_STB.m
@@ -19,8 +19,8 @@ S.U_act = speed / U;
 
 bin_count = zeros(1,num_bins);
 bin_std = zeros(1,num_bins);
-lift_phase_avg = zeros(1,num_bins);
-drag_phase_avg = zeros(1,num_bins);
+lift_phase_avg = struct();
+drag_phase_avg = struct();
 
 % Define the field names we want to average (must be same order as
 % import_STB)
@@ -64,6 +64,16 @@ for i = 1:num_bins
         for f = 1:length(fields)
             S.([fields{f} '_phase_avg']) = zeros(size(x,1), size(x,2), size(x,3), num_bins);
         end
+
+        lift_fields = fieldnames(lift_vals);
+        for f = 1:length(lift_fields)
+            lift_phase_avg.(lift_fields{f}) = zeros(1,num_bins);
+        end
+
+        drag_fields = fieldnames(drag_vals);
+        for f = 1:length(drag_fields)
+            drag_phase_avg.(drag_fields{f}) = zeros(1,num_bins);
+        end
     end
 
 
@@ -74,9 +84,18 @@ for i = 1:num_bins
 
         fname = [fields{f}, '_phase_std'];
         S.(fname)(:,:,:,i) = std(data{f}, 0, 4, "omitnan");
+    end
 
-        lift_phase_avg(i) = mean(lift_vals.vortX);
-        drag_phase_avg(i) = mean(drag_vals.tot);
+    for f = 1:length(lift_fields)
+        field_name = lift_fields{f};
+        cur_vals = lift_vals.(field_name);
+        lift_phase_avg.(field_name)(i) = mean(cur_vals(:), "omitnan");
+    end
+
+    for f = 1:length(drag_fields)
+        field_name = drag_fields{f};
+        cur_vals = drag_vals.(field_name);
+        drag_phase_avg.(field_name)(i) = mean(cur_vals(:), "omitnan");
     end
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Change `phase_avg_STB` to store `lift_phase_avg` and `drag_phase_avg` as structs.
- Initialize phase-average arrays from all fields returned by `get_wake_lift`.
- Average each returned lift/drag field per phase bin instead of only `lift.vortX` and `drag.tot`.

### Testing
- `git show --check --stat --oneline HEAD`
- Static wake force averaging check for `phase_avg_STB.m`
- MATLAB block-balance check for `phase_avg_STB.m`

### Notes
- MATLAB/Octave is not installed in this cloud environment, so runtime execution is limited to static validation here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2021c542-a8c7-420c-bef6-1b4ebd16b6d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2021c542-a8c7-420c-bef6-1b4ebd16b6d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

