### PR TITLE
Include case names in multi-index legends

### DIFF
--- a/Calimero/Flow Visualization/STB UI/compareWingbeatUI.m
+++ b/Calimero/Flow Visualization/STB UI/compareWingbeatUI.m
@@ -1046,10 +1046,8 @@ methods (Access = private)
             
             if has_legend_override
                 legend_entry = string(plot_options.legend_entry);
-            elseif isscalar(obj.inds)
-                legend_entry = strrep(cur_sel,"_"," ");
             else
-                legend_entry = obj.axes_labels(index);
+                legend_entry = obj.get_aligned_legend_entry(cur_sel, index, false);
             end
 
             if has_line_style


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Route non-aligned `plot_data` legend fallback through the existing case/variable legend helper.
- Preserve current single-index and single-selection labeling while adding `case - variable` labels when both `obj.selection` and `obj.inds` contain multiple entries.

### Testing
- `git show --check --stat --oneline HEAD`
- Static legend label routing check
- MATLAB block-balance check for `compareWingbeatUI.m`

### Notes
- MATLAB/Octave is not installed in this cloud environment, so runtime GUI validation is limited to static validation here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2021c542-a8c7-420c-bef6-1b4ebd16b6d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2021c542-a8c7-420c-bef6-1b4ebd16b6d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

