### PR TITLE
Preserve type order for all selections

### DIFF
--- a/Calimero/Flow Visualization/STB UI/compareWingbeatUI.m
+++ b/Calimero/Flow Visualization/STB UI/compareWingbeatUI.m
@@ -448,6 +448,13 @@ methods
             end
 
             matching_indices = find(type_mask & amp_mask & freq_mask);
+            [~, type_order] = ismember(selection_types(matching_indices), obj.cur_types);
+            type_order(type_order == 0) = length(obj.cur_types) + 1;
+            [~, sort_order] = sortrows([type_order(:),...
+                                        selection_amps(matching_indices),...
+                                        selection_freqs(matching_indices)]);
+            matching_indices = matching_indices(sort_order);
+
             for n = 1:length(matching_indices)
                 cur_idx = matching_indices(n);
                 case_name = selection_types(cur_idx) + "_" + string(selection_amps(cur_idx)) +...


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Sort matched selections before adding them to the list box.
- Preserve `obj.cur_types` order for the downstream `all` option so `flexible` appears before `UP_one_flexible` and `UP_two_flexible`.
- Keep deterministic amplitude and frequency ordering within each downstream type.

## Testing
- `python3` validation confirmed shuffled downstream selections are added in `obj.cur_types` order before amplitude/frequency ordering.
- `git diff --check HEAD~1..HEAD` passed.
- MATLAB/Octave GUI validation could not be run because neither executable is installed in the cloud environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e7fbe912-d38c-4067-9978-29f359922155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7fbe912-d38c-4067-9978-29f359922155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

