### PR TITLE
Refactor shared STB processing helpers

### DIFF
--- a/Calimero/Flow Visualization/STB Processing/processing functions/calc_secondary_vals.m
+++ b/Calimero/Flow Visualization/STB Processing/processing functions/calc_secondary_vals.m
@@ -1,31 +1,26 @@
 function calc_secondary_vals(D, turbine_bool, plot_bool, save_filepath_local)
 tic
-% Spatial resolution
-dx = abs(D.x(2,1,1) - D.x(1,1,1));
-dy = abs(D.y(1,2,1) - D.y(1,1,1));
-dz = abs(D.z(1,1,2) - D.z(1,1,1));
 
-% Replace NaNs with zeros, otherwise Q iso surfaces are holey
-% u_phase_avg = S.u_phase_avg;
-% u_phase_avg(isnan(u_phase_avg)) = 0;
-% 
-% v_phase_avg = S.v_phase_avg;
-% v_phase_avg(isnan(v_phase_avg)) = 0;
-% 
-% w_phase_avg = S.w_phase_avg;
-% w_phase_avg(isnan(w_phase_avg)) = 0;
-
-% Compute Q-Criterion
-[Qx,Qy,Qz,Q] = calQlate3D(D.u_phase_avg, D.v_phase_avg, D.w_phase_avg, dx,dy,dz);
-S.Qx = Qx; S.Qy = Qy; S.Qz = Qz; S.Q = Q;
-
-% Calculated using streamwise speed with freestream speed subtracted,
-% represents KE introduced by disturbance of flapper
-S.KE_diff_field = 2 * D.Utot_diff_phase_avg.^2; % x2 for L and R wings
-
-% Calculate power
-S.power_field = S.KE_diff_field .* -D.u_phase_avg; % remove +1 next to u_tr
-% negative sign added since -1.1 velocity means power added, acceleration
+config.uField = 'u_phase_avg';
+config.vField = 'v_phase_avg';
+config.wField = 'w_phase_avg';
+config.UtotField = 'Utot_phase_avg';
+config.UtotDiffField = 'Utot_diff_phase_avg';
+config.vortXField = 'vortX_phase_avg';
+config.vortYField = 'vortY_phase_avg';
+config.vortZField = 'vortZ_phase_avg';
+config.vortTotField = 'vortTot_phase_avg';
+config.uncField = 'uncTot_phase_avg';
+config.numPField = 'numP_phase_avg';
+config.helField = 'hel_phase_avg';
+config.dudxField = 'dudx_phase_avg';
+config.dvdxField = 'dvdx_phase_avg';
+config.dwdxField = 'dwdx_phase_avg';
+config.dvdyField = 'dvdy_phase_avg';
+config.dwdzField = 'dwdz_phase_avg';
+config.keDiffScale = 2; % x2 for L and R wings
+config.storeEnergyFields = true;
+config.includeDerivativePlanarAverages = true;
 
 if ~turbine_bool
 num_bins = D.num_bins;
@@ -36,137 +31,18 @@ x_conv = zeros(1, num_bins);
 for k = 1:num_bins
     x_conv(k) =  speed * dt * (k - 1);
 end
+
+config.xConv = x_conv;
+config.doWakeLift = true;
+config.includeVelocityWakeLift = true;
+config.includeHelmDecomp = true;
+config.wakeSpeed = speed;
+config.wakeLength = D.L;
+config.wakeAvgType = 1;
+config.wakeDensity = D.rho_act;
 end
 
-% ------------------------------------------------------------
-% Trim velocity field before calculating integral quantities
-% -------------------------------------------------------------
-y = D.y;
-z = D.z;
-u_tr = D.u_phase_avg;
-v_tr = D.v_phase_avg;
-w_tr = D.w_phase_avg;
-
-vortX_tr = D.vortX_phase_avg;
-vortY_tr = D.vortY_phase_avg;
-vortZ_tr = D.vortZ_phase_avg;
-
-unc_tr = D.uncTot_phase_avg;
-numP_tr = D.numP_phase_avg;
-hel_tr = D.hel_phase_avg;
-
-dudx_tr = D.dudx_phase_avg;
-dvdx_tr = D.dvdx_phase_avg;
-dwdx_tr = D.dwdx_phase_avg;
-
-KE_tr = S.KE_diff_field;
-power_tr = S.power_field;
-
-[y_tr, z_tr, u_tr] = trim_vel_field(y, z, u_tr);
-[~, ~, v_tr] = trim_vel_field(y, z, v_tr);
-[~, ~, w_tr] = trim_vel_field(y, z, w_tr);
-[~, ~, vortX_tr] = trim_vel_field(y, z, vortX_tr);
-[~, ~, vortY_tr] = trim_vel_field(y, z, vortY_tr);
-[~, ~, vortZ_tr] = trim_vel_field(y, z, vortZ_tr);
-[~, ~, unc_tr] = trim_vel_field(y, z, unc_tr);
-[~, ~, Utot_tr] = trim_vel_field(y, z, D.Utot_phase_avg);
-[~, ~, Utot_diff_tr] = trim_vel_field(y, z, D.Utot_diff_phase_avg);
-[~, ~, vortTot_tr] = trim_vel_field(y, z, D.vortTot_phase_avg);
-[~, ~, numP_tr] = trim_vel_field(y, z, numP_tr);
-[~, ~, hel_tr] = trim_vel_field(y, z, hel_tr);
-[~, ~, dudx_tr] = trim_vel_field(y, z, dudx_tr);
-[~, ~, dvdx_tr] = trim_vel_field(y, z, dvdx_tr);
-[~, ~, dwdx_tr] = trim_vel_field(y, z, dwdx_tr);
-[~, ~, KE_tr] = trim_vel_field(y, z, KE_tr);
-[~, ~, power_tr] = trim_vel_field(y, z, power_tr);
-
-% Replace nans in velocity field with median values so integral
-% calculations aren't skewed
-u_tr = nanToMedian(u_tr);
-v_tr = nanToMedian(v_tr);
-w_tr = nanToMedian(w_tr);
-
-y_arr = squeeze(y_tr(:,1));
-z_arr = squeeze(z_tr(1,:));
-
-if ~turbine_bool
-F.x = x_conv; F.y = y_tr; F.z = z_tr;
-F.u = u_tr; F.v = v_tr; F.w = w_tr;
-F.vortX = vortX_tr; F.vortY = vortY_tr; F.vortZ = vortZ_tr;
-F.unc = unc_tr;
-
-% Calculate lift and drag from wake
-avg_type = 1;
-[lift_vel, drag_vel] = get_wake_lift(speed, D.L, F, avg_type, false, D.rho_act);
-[lift, drag] = get_wake_lift(speed, D.L, F, avg_type, true, D.rho_act);
-S.lift = lift; S.drag = drag; S.lift_vel = lift_vel; S.drag_vel = drag_vel;
-
-% Calculate extrapolated field using Helmholtz decomposition
-[y_B, z_B, velX_B, velY_B, velZ_B] = helm_decomp(x_conv, y_arr, z_arr, D.L, F);
-S.y_B = y_B; S.z_B = z_B; S.velX_B = velX_B; S.velY_B = velY_B; S.velZ_B = velZ_B;
-
-% Caclulate KE from extrapolated field
-Utot_full = velX_B.^2 + velY_B.^2 + velZ_B.^2;
-KE_tot_field = permute(Utot_full,[2 3 1]);
-KE_tot = trapz(squeeze(y_B(:,1)), KE_tot_field, 1);
-KE_tot = trapz(squeeze(z_B(1,:)), KE_tot, 2);
-S.KE_tot = squeeze(KE_tot);
-end
-
-% Total KE including freestream KE
-KE_field = Utot_tr.^2;
-KE = trapz(y_arr, KE_field, 1);
-KE = trapz(z_arr, KE, 2);
-KE = squeeze(KE);
-
-% Calculated using streamwise speed with freestream speed subtracted,
-% represents KE introduced by disturbance of flapper
-KE_diff = trapz(y_arr, KE_tr, 1);
-KE_diff = trapz(z_arr, KE_diff, 2);
-KE_diff = squeeze(KE_diff);
-
-% Calculate power
-power = trapz(y_arr, power_tr, 1);
-power = trapz(z_arr, power, 2);
-power = squeeze(power);
-
-enst_field = vortTot_tr.^2;
-enst = trapz(y_arr, enst_field, 1);
-enst = trapz(z_arr, enst, 2);
-enst = squeeze(enst);
-
-div_field = D.dudx_phase_avg + D.dvdy_phase_avg + D.dwdz_phase_avg;
-
-S.KE = KE; S.KE_diff = KE_diff; S.enst = enst;
-S.power = power; S.div = div_field;
-
-% ----------------------------------------------------------------
-% --------------------- PLANAR AVERAGES --------------------------
-% ----------------------------------------------------------------
-% These values are vectors with length equal to the number of bins
-
-S.u_avg = mean(u_tr, [1, 2]);
-S.v_avg = mean(v_tr, [1, 2]);
-S.w_avg = mean(w_tr, [1, 2]);
-S.vortX_avg = mean(vortX_tr, [1, 2]);
-S.vortY_avg = mean(vortY_tr, [1, 2]);
-S.vortZ_avg = mean(vortZ_tr, [1, 2]);
-S.numP_avg = mean(numP_tr, [1, 2]);
-S.unc_avg = mean(unc_tr, [1, 2]);
-S.hel_avg = mean(hel_tr, [1, 2]);
-S.dudx_avg = mean(dudx_tr, [1, 2]);
-S.dvdx_avg = mean(dvdx_tr, [1, 2]);
-S.dwdx_avg = mean(dwdx_tr, [1, 2]);
-
-% The average can also be calculated using the linear interpolation of
-% trapz, this seems to be worse (more susceptible to noise)
-% u_avg = trapz(y_arr, u_tr, 1);
-% u_avg = trapz(z_arr, u_avg, 2);
-% 
-% Ly = y_arr(end) - y_arr(1);
-% Lz = z_arr(end) - z_arr(1);
-% 
-% u_avg = squeeze(u_avg) / (Ly * Lz);
+S = calc_secondary_vals_common(D, config);
 
 % ----------------------------------------------------------------
 % -------------- Calculate values from DAQ data ------------------

--- a/Calimero/Flow Visualization/STB Processing/processing functions/calc_secondary_vals_time.m
+++ b/Calimero/Flow Visualization/STB Processing/processing functions/calc_secondary_vals_time.m
@@ -1,146 +1,32 @@
 function calc_secondary_vals_time(D, save_filepath_local)
 tic
-% Spatial resolution
-dx = abs(D.x(2,1,1) - D.x(1,1,1));
-dy = abs(D.y(1,2,1) - D.y(1,1,1));
-dz = abs(D.z(1,1,2) - D.z(1,1,1));
 
-% Replace NaNs with zeros, otherwise Q iso surfaces are holey
-% u_phase_avg = S.u_phase_avg;
-% u_phase_avg(isnan(u_phase_avg)) = 0;
-% 
-% v_phase_avg = S.v_phase_avg;
-% v_phase_avg(isnan(v_phase_avg)) = 0;
-% 
-% w_phase_avg = S.w_phase_avg;
-% w_phase_avg(isnan(w_phase_avg)) = 0;
+config.uField = 'mean_u';
+config.vField = 'mean_v';
+config.wField = 'mean_w';
+config.UtotField = 'mean_Utot';
+config.UtotDiffField = 'mean_Utot_diff';
+config.vortXField = 'mean_vortX';
+config.vortYField = 'mean_vortY';
+config.vortZField = 'mean_vortZ';
+config.vortTotField = 'mean_vortTot';
+config.uncField = 'mean_uncTot';
+config.numPField = 'mean_numP';
+config.helField = 'mean_hel';
+config.dudxField = 'mean_dudx';
+config.dvdxField = 'mean_dvdx';
+config.dwdxField = 'mean_dwdx';
+config.dvdyField = 'mean_dvdy';
+config.dwdzField = 'mean_dwdz';
+config.keDiffScale = 1;
+config.doWakeLift = true;
+config.includeVelocityWakeLift = true;
+config.wakeSpeed = D.U;
+config.wakeLength = D.L;
+config.wakeAvgType = 0;
+config.wakeDensity = D.rho;
 
-% Compute Q-Criterion
-[Qx,Qy,Qz,Q] = calQlate3D(D.mean_u, D.mean_v, D.mean_w, dx,dy,dz);
-S.Qx = Qx; S.Qy = Qy; S.Qz = Qz; S.Q = Q;
-
-x_conv = 0;
-% ------------------------------------------------------------
-% Trim velocity field before calculating integral quantities
-% -------------------------------------------------------------
-y = D.y;
-z = D.z;
-u_tr = D.mean_u;
-v_tr = D.mean_v;
-w_tr = D.mean_w;
-
-vortX_tr = D.mean_vortX;
-vortY_tr = D.mean_vortY;
-vortZ_tr = D.mean_vortZ;
-
-unc_tr = D.mean_uncTot;
-numP_tr = D.mean_numP;
-hel_tr = D.mean_hel;
-
-dudx_tr = D.mean_dudx;
-dvdx_tr = D.mean_dvdx;
-dwdx_tr = D.mean_dwdx;
-
-[y_tr, z_tr, u_tr] = trim_vel_field(y, z, u_tr);
-[~, ~, v_tr] = trim_vel_field(y, z, v_tr);
-[~, ~, w_tr] = trim_vel_field(y, z, w_tr);
-[~, ~, vortX_tr] = trim_vel_field(y, z, vortX_tr);
-[~, ~, vortY_tr] = trim_vel_field(y, z, vortY_tr);
-[~, ~, vortZ_tr] = trim_vel_field(y, z, vortZ_tr);
-[~, ~, unc_tr] = trim_vel_field(y, z, unc_tr);
-[~, ~, Utot_tr] = trim_vel_field(y, z, D.mean_Utot);
-[~, ~, Utot_diff_tr] = trim_vel_field(y, z, D.mean_Utot_diff);
-[~, ~, vortTot_tr] = trim_vel_field(y, z, D.mean_vortTot);
-[~, ~, numP_tr] = trim_vel_field(y, z, numP_tr);
-[~, ~, hel_tr] = trim_vel_field(y, z, hel_tr);
-[~, ~, dudx_tr] = trim_vel_field(y, z, dudx_tr);
-[~, ~, dvdx_tr] = trim_vel_field(y, z, dvdx_tr);
-[~, ~, dwdx_tr] = trim_vel_field(y, z, dwdx_tr);
-
-% Replace nans in velocity field with median values so integral
-% calculations aren't skewed
-u_tr = nanToMedian(u_tr);
-v_tr = nanToMedian(v_tr);
-w_tr = nanToMedian(w_tr);
-
-F.x = x_conv; F.y = y_tr; F.z = z_tr;
-F.u = u_tr; F.v = v_tr; F.w = w_tr;
-F.vortX = vortX_tr; F.vortY = vortY_tr; F.vortZ = vortZ_tr;
-F.unc = unc_tr;
-
-% Calculate lift and drag from wake
-avg_type = 0;
-[lift_vel, drag_vel] = get_wake_lift(D.U, D.L, F, avg_type, false, D.rho);
-[lift, drag] = get_wake_lift(D.U, D.L, F, avg_type, true, D.rho);
-S.lift = lift; S.drag = drag; S.lift_vel = lift_vel; S.drag_vel = drag_vel;
-
-% Calculate extrapolated field using Helmholtz decomposition
-y_arr = squeeze(y_tr(:,1));
-z_arr = squeeze(z_tr(1,:));
-% [y_B, z_B, velX_B, velY_B, velZ_B] = helm_decomp(x_conv, y_arr, z_arr, D.L, F);
-% S.y_B = y_B; S.z_B = z_B; S.velX_B = velX_B; S.velY_B = velY_B; S.velZ_B = velZ_B;
-
-% Utot_full = velX_B.^2 + velY_B.^2 + velZ_B.^2;
-% KE_tot_field = permute(Utot_full,[2 3 1]);
-% KE_tot = trapz(squeeze(y_B(:,1)), KE_tot_field, 1);
-% KE_tot = trapz(squeeze(z_B(1,:)), KE_tot, 2);
-% KE_tot = squeeze(KE_tot);
-% S.KE_tot = KE_tot;
-
-% Total KE including freestream KE
-KE_field = Utot_tr.^2;
-KE = trapz(y_arr, KE_field, 1);
-KE = trapz(z_arr, KE, 2);
-KE = squeeze(KE);
-
-% Calculated using streamwise speed with freestream speed subtracted,
-% represents KE introduced by disturbance of flapper
-KE_diff_field = Utot_diff_tr.^2;
-KE_diff = trapz(y_arr, KE_diff_field, 1);
-KE_diff = trapz(z_arr, KE_diff, 2);
-KE_diff = squeeze(KE_diff);
-
-% Calculate power
-power_field = KE_diff_field .* -u_tr; % remove +1 next to u_tr
-% negative sign added since -1.1 velocity means power added, acceleration
-power = trapz(y_arr, power_field, 1);
-power = trapz(z_arr, power, 2);
-power = squeeze(power);
-
-enst_field = vortTot_tr.^2;
-enst = trapz(y_arr, enst_field, 1);
-enst = trapz(z_arr, enst, 2);
-enst = squeeze(enst);
-
-div_field = D.mean_dudx + D.mean_dvdy + D.mean_dwdz;
-
-S.KE = KE; S.KE_diff = KE_diff; S.enst = enst;
-S.power = power; S.div = div_field;
-
-% ----------------------------------------------------------------
-% --------------------- PLANAR AVERAGES --------------------------
-% ----------------------------------------------------------------
-% These values are vectors with length equal to the number of bins
-
-S.u_avg = mean(u_tr, [1, 2]);
-S.v_avg = mean(v_tr, [1, 2]);
-S.w_avg = mean(w_tr, [1, 2]);
-S.vortX_avg = mean(vortX_tr, [1, 2]);
-S.vortY_avg = mean(vortY_tr, [1, 2]);
-S.vortZ_avg = mean(vortZ_tr, [1, 2]);
-S.numP_avg = mean(numP_tr, [1, 2]);
-S.unc_avg = mean(unc_tr, [1, 2]);
-S.hel_avg = mean(hel_tr, [1, 2]);
-
-% The average can also be calculated using the linear interpolation of
-% trapz, this seems to be worse (more susceptible to noise)
-% u_avg = trapz(y_arr, u_tr, 1);
-% u_avg = trapz(z_arr, u_avg, 2);
-% 
-% Ly = y_arr(end) - y_arr(1);
-% Lz = z_arr(end) - z_arr(1);
-% 
-% u_avg = squeeze(u_avg) / (Ly * Lz);
+S = calc_secondary_vals_common(D, config);
 
 % Save the entire structure
 save_filename = D.PIV_case_name + "_time_avg_integral.mat";

--- a/Calimero/Flow Visualization/STB Processing/processing functions/general helpers/calc_secondary_vals_common.m
+++ b/Calimero/Flow Visualization/STB Processing/processing functions/general helpers/calc_secondary_vals_common.m
@@ -1,0 +1,123 @@
+function S = calc_secondary_vals_common(D, config)
+%CALC_SECONDARY_VALS_COMMON Shared secondary calculations for STB averages.
+
+config = set_defaults(config);
+
+% Spatial resolution
+dx = abs(D.x(2,1,1) - D.x(1,1,1));
+dy = abs(D.y(1,2,1) - D.y(1,1,1));
+dz = abs(D.z(1,1,2) - D.z(1,1,1));
+
+% Compute Q-Criterion
+[Qx,Qy,Qz,Q] = calQlate3D(D.(config.uField), D.(config.vField), D.(config.wField), dx,dy,dz);
+S.Qx = Qx; S.Qy = Qy; S.Qz = Qz; S.Q = Q;
+
+% Calculated using streamwise speed with freestream speed subtracted.
+KE_diff_field = config.keDiffScale * D.(config.UtotDiffField).^2;
+power_field = KE_diff_field .* -D.(config.uField);
+
+if config.storeEnergyFields
+    S.KE_diff_field = KE_diff_field;
+    S.power_field = power_field;
+end
+
+trim_source.u = D.(config.uField);
+trim_source.v = D.(config.vField);
+trim_source.w = D.(config.wField);
+trim_source.vortX = D.(config.vortXField);
+trim_source.vortY = D.(config.vortYField);
+trim_source.vortZ = D.(config.vortZField);
+trim_source.unc = D.(config.uncField);
+trim_source.Utot = D.(config.UtotField);
+trim_source.Utot_diff = D.(config.UtotDiffField);
+trim_source.vortTot = D.(config.vortTotField);
+trim_source.numP = D.(config.numPField);
+trim_source.hel = D.(config.helField);
+trim_source.dudx = D.(config.dudxField);
+trim_source.dvdx = D.(config.dvdxField);
+trim_source.dwdx = D.(config.dwdxField);
+trim_source.KE_diff = KE_diff_field;
+trim_source.power = power_field;
+
+[F, y_tr, z_tr, T] = prepare_STB_wake_field(D.y, D.z, trim_source, config.xConv, true);
+
+y_arr = squeeze(y_tr(:,1));
+z_arr = squeeze(z_tr(1,:));
+
+if config.doWakeLift
+    if config.includeVelocityWakeLift
+        [lift_vel, drag_vel] = get_wake_lift(config.wakeSpeed, config.wakeLength, F, config.wakeAvgType, false, config.wakeDensity);
+        S.lift_vel = lift_vel; S.drag_vel = drag_vel;
+    end
+
+    [lift, drag] = get_wake_lift(config.wakeSpeed, config.wakeLength, F, config.wakeAvgType, true, config.wakeDensity);
+    S.lift = lift; S.drag = drag;
+end
+
+if config.includeHelmDecomp
+    [y_B, z_B, velX_B, velY_B, velZ_B] = helm_decomp(config.xConv, y_arr, z_arr, config.wakeLength, F);
+    S.y_B = y_B; S.z_B = z_B; S.velX_B = velX_B; S.velY_B = velY_B; S.velZ_B = velZ_B;
+
+    Utot_full = velX_B.^2 + velY_B.^2 + velZ_B.^2;
+    KE_tot_field = permute(Utot_full,[2 3 1]);
+    KE_tot = trapz(squeeze(y_B(:,1)), KE_tot_field, 1);
+    KE_tot = trapz(squeeze(z_B(1,:)), KE_tot, 2);
+    S.KE_tot = squeeze(KE_tot);
+end
+
+% Integral quantities
+S.KE = integrate_planar(y_arr, z_arr, T.Utot.^2);
+S.KE_diff = integrate_planar(y_arr, z_arr, T.KE_diff);
+S.power = integrate_planar(y_arr, z_arr, T.power);
+S.enst = integrate_planar(y_arr, z_arr, T.vortTot.^2);
+S.div = D.(config.dudxField) + D.(config.dvdyField) + D.(config.dwdzField);
+
+% Planar averages
+S.u_avg = mean(T.u, [1, 2]);
+S.v_avg = mean(T.v, [1, 2]);
+S.w_avg = mean(T.w, [1, 2]);
+S.vortX_avg = mean(T.vortX, [1, 2]);
+S.vortY_avg = mean(T.vortY, [1, 2]);
+S.vortZ_avg = mean(T.vortZ, [1, 2]);
+S.numP_avg = mean(T.numP, [1, 2]);
+S.unc_avg = mean(T.unc, [1, 2]);
+S.hel_avg = mean(T.hel, [1, 2]);
+
+if config.includeDerivativePlanarAverages
+    S.dudx_avg = mean(T.dudx, [1, 2]);
+    S.dvdx_avg = mean(T.dvdx, [1, 2]);
+    S.dwdx_avg = mean(T.dwdx, [1, 2]);
+end
+end
+
+function config = set_defaults(config)
+if ~isfield(config, 'xConv')
+    config.xConv = 0;
+end
+
+if ~isfield(config, 'doWakeLift')
+    config.doWakeLift = false;
+end
+
+if ~isfield(config, 'includeVelocityWakeLift')
+    config.includeVelocityWakeLift = false;
+end
+
+if ~isfield(config, 'includeHelmDecomp')
+    config.includeHelmDecomp = false;
+end
+
+if ~isfield(config, 'includeDerivativePlanarAverages')
+    config.includeDerivativePlanarAverages = false;
+end
+
+if ~isfield(config, 'storeEnergyFields')
+    config.storeEnergyFields = false;
+end
+end
+
+function value = integrate_planar(y_arr, z_arr, field)
+value = trapz(y_arr, field, 1);
+value = trapz(z_arr, value, 2);
+value = squeeze(value);
+end

--- a/Calimero/Flow Visualization/STB Processing/processing functions/general helpers/get_STB_processing_fields.m
+++ b/Calimero/Flow Visualization/STB Processing/processing functions/general helpers/get_STB_processing_fields.m
@@ -1,0 +1,6 @@
+function fields = get_STB_processing_fields()
+%GET_STB_PROCESSING_FIELDS Field order returned by import_STB_data.
+
+fields = {'u', 'v', 'w', 'Utot', 'vortX', 'vortY', 'vortZ', 'vortTot', 'uncU', 'uncV', 'uncW', 'uncTot', 'hel', 'numP',...
+        'dudx', 'dudy', 'dudz', 'dvdx', 'dvdy', 'dvdz', 'dwdx', 'dwdy', 'dwdz', 'Utot_diff'};
+end

--- a/Calimero/Flow Visualization/STB Processing/processing functions/general helpers/prepare_STB_wake_field.m
+++ b/Calimero/Flow Visualization/STB Processing/processing functions/general helpers/prepare_STB_wake_field.m
@@ -1,0 +1,55 @@
+function [F, y_tr, z_tr, T] = prepare_STB_wake_field(y, z, source, x_conv, fill_velocity_nans)
+%PREPARE_STB_WAKE_FIELD Trim STB fields and build get_wake_lift input.
+
+if nargin < 4
+    x_conv = 0;
+end
+
+if nargin < 5
+    fill_velocity_nans = false;
+end
+
+T = trim_STB_source_fields(y, z, source);
+
+if fill_velocity_nans
+    T.u = nanToMedian(T.u);
+    T.v = nanToMedian(T.v);
+    T.w = nanToMedian(T.w);
+end
+
+y_tr = T.y;
+z_tr = T.z;
+
+F.x = x_conv; F.y = y_tr; F.z = z_tr;
+F.u = T.u; F.v = T.v; F.w = T.w;
+F.vortX = T.vortX; F.vortY = T.vortY; F.vortZ = T.vortZ;
+
+if isfield(T, 'unc')
+    F.unc = T.unc;
+else
+    F.unc = T.uncTot;
+end
+end
+
+function T = trim_STB_source_fields(y, z, source)
+if iscell(source)
+    source = import_data_to_struct(source);
+end
+
+names = fieldnames(source);
+[T.y, T.z, T.(names{1})] = trim_vel_field(y, z, source.(names{1}));
+
+for i = 2:numel(names)
+    [~, ~, T.(names{i})] = trim_vel_field(y, z, source.(names{i}));
+end
+end
+
+function S = import_data_to_struct(data)
+S.u = data{1};
+S.v = data{2};
+S.w = data{3};
+S.vortX = data{5};
+S.vortY = data{6};
+S.vortZ = data{7};
+S.uncTot = data{12};
+end

--- a/Calimero/Flow Visualization/STB Processing/processing functions/phase_avg_STB.m
+++ b/Calimero/Flow Visualization/STB Processing/processing functions/phase_avg_STB.m
@@ -33,10 +33,7 @@ bin_std = zeros(1,num_bins);
 lift_phase_avg = struct();
 drag_phase_avg = struct();
 
-% Define the field names we want to average (must be same order as
-% import_STB)
-fields = {'u', 'v', 'w', 'Utot', 'vortX', 'vortY', 'vortZ', 'vortTot', 'uncU', 'uncV', 'uncW', 'uncTot', 'hel', 'numP',...
-        'dudx', 'dudy', 'dudz', 'dvdx', 'dvdy', 'dvdz', 'dwdx', 'dwdy', 'dwdz', 'Utot_diff'};
+fields = get_STB_processing_fields();
 
 for i = 1:num_bins
     bin_indices = find(bin_ind_arr == i);
@@ -49,25 +46,7 @@ for i = 1:num_bins
         import_STB_data(file_path, bools.nondim, U, L, bin_indices, bools.RPCA);
 
     avg_type = 2;
-
-    x_conv = 0;
-
-    u_tr = data{1}; v_tr = data{2}; w_tr = data{3};
-    vortX_tr = data{5}; vortY_tr = data{6}; vortZ_tr = data{7};
-    unc_tr = data{12};
-
-    [y_tr, z_tr, u_tr] = trim_vel_field(y, z, u_tr);
-    [~, ~, v_tr] = trim_vel_field(y, z, v_tr);
-    [~, ~, w_tr] = trim_vel_field(y, z, w_tr);
-    [~, ~, vortX_tr] = trim_vel_field(y, z, vortX_tr);
-    [~, ~, vortY_tr] = trim_vel_field(y, z, vortY_tr);
-    [~, ~, vortZ_tr] = trim_vel_field(y, z, vortZ_tr);
-    [~, ~, unc_tr] = trim_vel_field(y, z, unc_tr);
-
-    F.x = x_conv; F.y = y_tr; F.z = z_tr;
-    F.u = u_tr; F.v = v_tr; F.w = w_tr;
-    F.vortX = vortX_tr; F.vortY = vortY_tr; F.vortZ = vortZ_tr;
-    F.unc = unc_tr;
+    F = prepare_STB_wake_field(y, z, data, 0);
 
     if ~bools.turbine
     [lift_vals, drag_vals] = get_wake_lift(speed, L, F, avg_type, true, S.rho_act);

--- a/Calimero/Flow Visualization/STB Processing/processing functions/time_avg_STB.m
+++ b/Calimero/Flow Visualization/STB Processing/processing functions/time_avg_STB.m
@@ -13,10 +13,7 @@ function S = time_avg_STB(file_path, nondim_bool, U, L, num_files, save_filepath
     lift_vals = zeros(1,num_files);
     drag_vals = zeros(1,num_files);
 
-    % Define the field names we want to average (must be same order as
-    % import_STB)
-    fields = {'u', 'v', 'w', 'Utot', 'vortX', 'vortY', 'vortZ', 'vortTot', 'uncU', 'uncV', 'uncW', 'uncTot', 'hel', 'numP',...
-        'dudx', 'dudy', 'dudz', 'dvdx', 'dvdy', 'dvdz', 'dwdx', 'dwdy', 'dwdz', 'Utot_diff'};
+    fields = get_STB_processing_fields();
     
     for i = 1:num_files
         % Import data (using a temporary struct or list)
@@ -38,25 +35,7 @@ function S = time_avg_STB(file_path, nondim_bool, U, L, num_files, save_filepath
         end
 
         avg_type = 2;
-
-        x_conv = 0;
-
-        u_tr = data{1}; v_tr = data{2}; w_tr = data{3};
-        vortX_tr = data{5}; vortY_tr = data{6}; vortZ_tr = data{7};
-        unc_tr = data{12};
-    
-        [y_tr, z_tr, u_tr] = trim_vel_field(y, z, u_tr);
-        [~, ~, v_tr] = trim_vel_field(y, z, v_tr);
-        [~, ~, w_tr] = trim_vel_field(y, z, w_tr);
-        [~, ~, vortX_tr] = trim_vel_field(y, z, vortX_tr);
-        [~, ~, vortY_tr] = trim_vel_field(y, z, vortY_tr);
-        [~, ~, vortZ_tr] = trim_vel_field(y, z, vortZ_tr);
-        [~, ~, unc_tr] = trim_vel_field(y, z, unc_tr);
-    
-        F.x = x_conv; F.y = y_tr; F.z = z_tr;
-        F.u = u_tr; F.v = v_tr; F.w = w_tr;
-        F.vortX = vortX_tr; F.vortY = vortY_tr; F.vortZ = vortZ_tr;
-        F.unc = unc_tr;
+        F = prepare_STB_wake_field(y, z, data, 0);
 
         [lift, drag] = get_wake_lift(speed, L, F, avg_type, true, density);
         lift_vals(i) = lift.vortX;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Extract shared STB import field ordering into `get_STB_processing_fields`.
- Extract wake-field trimming/setup into `prepare_STB_wake_field`.
- Consolidate duplicated secondary Q, wake-lift, integral, and planar-average calculations in `calc_secondary_vals_common`.

### Testing
- `git diff --check HEAD~1 HEAD`
- `python3` static MATLAB refactor check covering helper wiring, required config coverage, STB field-list ordering, and block balance.

### Notes
- No Octave/MATLAB runtime is installed in the cloud environment, so full `.m` execution was not available here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4eafda99-534e-4077-9ff1-233fb9050849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4eafda99-534e-4077-9ff1-233fb9050849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

