### PR TITLE
Apply convection shift before time average alignment

### DIFF
--- a/Calimero/Flow Visualization/STB UI/timeAvg_UI.m
+++ b/Calimero/Flow Visualization/STB UI/timeAvg_UI.m
@@ -569,26 +569,30 @@ classdef timeAvg_UI < handle
                             idx = 3;
                         end
 
-                        force_signal = get_force(obj.force_path, type, amp, freqs(j), idx, var_name_F);
+                        if is_shift_operation && freqs(j) == 0
+                            disp("Skipping 0 Hz force case for phase shift")
+                        else
+                            force_signal = get_force(obj.force_path, type, amp, freqs(j), idx, var_name_F);
 
-                        if is_shift_operation && freqs(j) > 0
-                            force_signals{j} = force_signal;
-                        elseif strcmp(obj.operation, "mean")
-                            forces(2,j) = mean(force_signal);
-                        elseif strcmp(obj.operation, "range")
-                            forces(2,j) = range(force_signal);
-                        end
-
-                        if obj.force_sub
-                            body_amp = amp;
-                            if body_amp == 30
-                                body_amp = 20;
+                            if is_shift_operation
+                                force_signals{j} = force_signal;
+                            elseif strcmp(obj.operation, "mean")
+                                forces(2,j) = mean(force_signal);
+                            elseif strcmp(obj.operation, "range")
+                                forces(2,j) = range(force_signal);
                             end
-                            body_force = get_force(obj.force_path, "body", body_amp, freqs(j), idx, var_name_F);
-                            if is_shift_operation && freqs(j) > 0
-                                force_signals{j} = obj.subtract_alignment_body_signal(force_signal, body_force);
-                            else
-                                forces(2,j) = forces(2,j) - mean(body_force);
+
+                            if obj.force_sub
+                                body_amp = amp;
+                                if body_amp == 30
+                                    body_amp = 20;
+                                end
+                                body_force = get_force(obj.force_path, "body", body_amp, freqs(j), idx, var_name_F);
+                                if is_shift_operation
+                                    force_signals{j} = obj.subtract_alignment_body_signal(force_signal, body_force);
+                                else
+                                    forces(2,j) = forces(2,j) - mean(body_force);
+                                end
                             end
                         end
                     end

--- a/Calimero/Flow Visualization/STB UI/timeAvg_UI.m
+++ b/Calimero/Flow Visualization/STB UI/timeAvg_UI.m
@@ -546,6 +546,9 @@ classdef timeAvg_UI < handle
                         
                         % Calculate mean force and store in array for plotting
                         if is_shift_operation && freqs(j) > 0
+                            if obj.is_piv_force_variable()
+                                var = obj.apply_convection_shift(var, type, measured_freqs(j));
+                            end
                             PIV_signals{j} = var;
                         elseif strcmp(obj.operation, "mean")
                             forces(1,j) = mean(var);
@@ -734,6 +737,28 @@ classdef timeAvg_UI < handle
 
             signal = signal(:);
             valid = length(signal) > 1 && all(isfinite(signal)) && std(signal) > 0;
+        end
+
+        function signal = apply_convection_shift(~, signal, type, freq_cor)
+            dist = 0.9;
+            sep_dist = 0.37;
+            if contains(type, "UP_two")
+                dist = dist + sep_dist*2;
+            elseif contains(type, "UP_one")
+                dist = dist + sep_dist;
+            end
+
+            speed = 4;
+            conv_time = dist / speed;
+            shift = conv_time * freq_cor;
+            shift_samples = round(shift*length(signal));
+            signal = circshift(signal, shift_samples);
+            disp("Shifted by: " + shift_samples + " / " + length(signal))
+        end
+
+        function force_variable = is_piv_force_variable(obj)
+            force_index = find(obj.var_names == obj.force_var, 1);
+            force_variable = ~isempty(force_index) && force_index <= 6;
         end
 
         function signal = subtract_alignment_body_signal(~, signal, body_signal)

--- a/Calimero/Flow Visualization/STB UI/timeAvg_UI.m
+++ b/Calimero/Flow Visualization/STB UI/timeAvg_UI.m
@@ -8,7 +8,7 @@ classdef timeAvg_UI < handle
     properties (Constant)
         COLOR_ACTIVE = [0.3010 0.7450 0.9330];
         COLOR_INACTIVE = [1 1 1];
-        operations = ["mean", "range"];
+        operations = ["mean", "range", "shift"];
         cur_types = ["flexible";"UP_one_flexible";"UP_two_flexible"];
     end
 
@@ -450,6 +450,8 @@ classdef timeAvg_UI < handle
             l = legend(ax, Location="best");
             set(ax, FontSize=18)
 
+            is_shift_operation = strcmp(obj.operation, "shift");
+
             for i = 1:length(obj.selection) % Loop through each selection
                 [amp, type] = parse_name(obj.selection(i));
 
@@ -458,8 +460,13 @@ classdef timeAvg_UI < handle
                 mask = cell2mat(obj.available_selections(:,2)) == amp & strcmp(string(obj.available_selections(:,1)), type);
                 freqs = cell2mat(obj.available_selections(mask,3));
                 forces = zeros(2, length(freqs));
+                if is_shift_operation
+                    forces(:) = NaN;
+                end
                 errors = zeros(1, length(freqs));
-                measured_freqs = zeros(1, length(freqs));
+                measured_freqs = freqs;
+                PIV_signals = cell(1, length(freqs));
+                force_signals = cell(1, length(freqs));
                 
                 for j = 1:length(freqs) % Loop through all wingbeat frequencies
                     if obj.PIV_bool
@@ -492,7 +499,9 @@ classdef timeAvg_UI < handle
                             % errors(j) = 0.2 / length(d.bin_std);
                         end
 
-                        if obj.calc_bool
+                        if is_shift_operation && freqs(j) == 0
+                            disp("Skipping 0 Hz time-average case for phase shift")
+                        elseif obj.calc_bool
                             [var, err] = get_PIV_force(filepath, name, obj.force_var, avg_type, obj.y_norm, obj.y_cen);
 
                             if obj.PIV_sub
@@ -502,7 +511,7 @@ classdef timeAvg_UI < handle
                                 [bod_var, ~] = get_PIV_force(bod_filepath, "", obj.force_var, 0, obj.y_norm, obj.y_cen);
                                 var = var - bod_var;
                             end
-                        else
+                        elseif ~is_shift_operation || freqs(j) > 0
                             if contains(obj.force_var, ".")
                                 abbrv_name = extractBefore(obj.force_var, ".");
                                 d = load(secondary_filepath, abbrv_name);
@@ -533,10 +542,12 @@ classdef timeAvg_UI < handle
                                 end
                                 var = var - bod_var;
                             end  
-                        end                    
+                        end
                         
                         % Calculate mean force and store in array for plotting
-                        if strcmp(obj.operation, "mean")
+                        if is_shift_operation && freqs(j) > 0
+                            PIV_signals{j} = var;
+                        elseif strcmp(obj.operation, "mean")
                             forces(1,j) = mean(var);
                         elseif strcmp(obj.operation, "range")
                             forces(1,j) = range(var);
@@ -558,10 +569,14 @@ classdef timeAvg_UI < handle
                             idx = 3;
                         end
 
-                        if strcmp(obj.operation, "mean")
-                            forces(2,j) = mean(get_force(obj.force_path, type, amp, freqs(j), idx, var_name_F));
+                        force_signal = get_force(obj.force_path, type, amp, freqs(j), idx, var_name_F);
+
+                        if is_shift_operation && freqs(j) > 0
+                            force_signals{j} = force_signal;
+                        elseif strcmp(obj.operation, "mean")
+                            forces(2,j) = mean(force_signal);
                         elseif strcmp(obj.operation, "range")
-                            forces(2,j) = range(get_force(obj.force_path, type, amp, freqs(j), idx, var_name_F));
+                            forces(2,j) = range(force_signal);
                         end
 
                         if obj.force_sub
@@ -569,16 +584,31 @@ classdef timeAvg_UI < handle
                             if body_amp == 30
                                 body_amp = 20;
                             end
-                            body_force = mean(get_force(obj.force_path, "body", body_amp, freqs(j), idx, var_name_F));
-                            forces(2,j) = forces(2,j) - body_force;
+                            body_force = get_force(obj.force_path, "body", body_amp, freqs(j), idx, var_name_F);
+                            if is_shift_operation && freqs(j) > 0
+                                force_signals{j} = obj.subtract_alignment_body_signal(force_signal, body_force);
+                            else
+                                forces(2,j) = forces(2,j) - mean(body_force);
+                            end
                         end
                     end
                     disp(j + " of " + length(freqs) + " complete")
                 end
 
+                if is_shift_operation
+                    if obj.PIV_bool
+                        forces(1,:) = obj.calculate_phase_shifts(PIV_signals);
+                    end
+                    if obj.force_bool && ~contains(type, "UP")
+                        forces(2,:) = obj.calculate_phase_shifts(force_signals);
+                    end
+                end
+
                 % Calculate gain based on range of values
-                gain = range(forces(1,:))/2;
-                errors = gain * errors;
+                if ~is_shift_operation
+                    gain = range(forces(1,:))/2;
+                    errors = gain * errors;
+                end
 
                 % x-axis is either wingbeat frequency or Strouhal number
                 if obj.x_norm
@@ -592,7 +622,24 @@ classdef timeAvg_UI < handle
 
                 xlabel(ax, x_label, Interpreter="latex")
 
-                if obj.err_bool
+                if is_shift_operation
+                    ylabel(ax, "Phase shift (cycles)")
+
+                    if obj.PIV_bool
+                        s1 = scatter(ax, x_var, forces(1,:), 125, "filled");
+                        s1.Marker = "o";
+                        s1.MarkerFaceColor = original_color;
+                        s1.MarkerEdgeColor = original_color;
+                        s1.DisplayName = "PIV shift: " + strrep(type,"_"," ") + ", " + amp + " deg";
+                    end
+
+                    if obj.force_bool && ~contains(type, "UP")
+                        s2 = scatter(ax, x_var, forces(2,:), 125, "filled");
+                        s2.Marker = "p";
+                        s2.MarkerFaceColor = original_color;
+                        s2.DisplayName = "Force shift: " + strrep(type,"_"," ") + ", " + amp + " deg";
+                    end
+                elseif obj.err_bool
                     ylabel(ax, "Error (N)")
 
                     error = (forces(1,:) - forces(2,:));
@@ -641,6 +688,63 @@ classdef timeAvg_UI < handle
                 savefig(fignew,filename);
                 delete(fignew);
             end
+        end
+
+        function phase_shifts = calculate_phase_shifts(obj, signals)
+            phase_shifts = NaN(1, length(signals));
+            valid_indices = find(cellfun(@(signal) obj.is_valid_alignment_signal(signal), signals));
+
+            if isempty(valid_indices)
+                return
+            end
+
+            lengths = cellfun(@(signal) length(signal), signals(valid_indices));
+            interp_length = min(lengths);
+            time_interp = (1:interp_length) / interp_length;
+            interp_signals = cell(1, length(signals));
+
+            for i = 1:length(valid_indices)
+                signal_idx = valid_indices(i);
+                signal = signals{signal_idx};
+                signal = signal(:)';
+                time = (1:length(signal)) / length(signal);
+                interp_signals{signal_idx} = interp1(time, signal, time_interp, 'pchip');
+            end
+
+            reference_idx = valid_indices(1);
+            reference_signal = interp_signals{reference_idx};
+            phase_shifts(reference_idx) = 0;
+
+            for i = 2:length(valid_indices)
+                signal_idx = valid_indices(i);
+                [~, lag_in_samples] = align_signals(reference_signal, interp_signals{signal_idx});
+                phase_shifts(signal_idx) = lag_in_samples / interp_length;
+            end
+        end
+
+        function valid = is_valid_alignment_signal(~, signal)
+            if isempty(signal)
+                valid = false;
+                return
+            end
+
+            signal = signal(:);
+            valid = length(signal) > 1 && all(isfinite(signal)) && std(signal) > 0;
+        end
+
+        function signal = subtract_alignment_body_signal(~, signal, body_signal)
+            signal = signal(:)';
+            body_signal = body_signal(:)';
+
+            if length(signal) == length(body_signal)
+                signal = signal - body_signal;
+                return
+            end
+
+            signal_time = (1:length(signal)) / length(signal);
+            body_time = (1:length(body_signal)) / length(body_signal);
+            body_signal = interp1(body_time, body_signal, signal_time, 'pchip');
+            signal = signal - body_signal;
         end
     end
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Apply the same convection-time shift used by `phaseAvg_UI` to PIV force-derived signals before `timeAvg_UI` computes shift-mode alignment lags.
- Merge the latest `Calimero` into this branch and resolve the single simple conflict in `timeAvg_UI.m` by preserving the branch-side convection-shift additions.
- Keep the shift scoped to PIV force variables and leave force-transducer signals unshifted.

### Conflict review
- Simple conflict: `Calimero/Flow Visualization/STB UI/timeAvg_UI.m` overlapped where this branch adds the convection-shift call and helper methods on top of shift-mode code already present in `Calimero`.
- Complicated conflicts: none found.

### Testing
- `git diff --check Calimero..HEAD` passed.
- `git diff --name-only --diff-filter=U` confirmed no unmerged files remain.
- Conflict-marker search found no remaining markers in `timeAvg_UI.m`.
- Environment check confirmed MATLAB/Octave is not installed in this cloud VM, so the MATLAB UI could not be launched or syntax-checked here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e4a86cf-d55c-4543-aff6-7ecccb551b02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e4a86cf-d55c-4543-aff6-7ecccb551b02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

