### PR TITLE
Add RK4 particle tracking visualization

### DIFF
--- a/Calimero/Flow Visualization/FTLE_test.m
+++ b/Calimero/Flow Visualization/FTLE_test.m
@@ -5,29 +5,144 @@ filepath = "Y:\Processed Results\phase_avg\flexible_20deg_6Hz_phase_avg.mat";
 
 TRIM_Y_BOUNDS = [-2.26 2]; % roughly -0.15 to 0.15 m
 TRIM_Z_BOUNDS = [-2.36 2.55]; % roughly -0.2 to 0.2 m
+SOURCE_X_INDEX = 3;
+
+particle_dt = (1 / 6) / 125;
+num_particle_timesteps = 125;
+plot_seed_stride = [4 4 8]; % [y z x] stride used only for plotting
+plot_particle_tracks = true;
+if strcmp(getenv("FTLE_DISABLE_PARTICLE_PLOT"), "1")
+    plot_particle_tracks = false;
+end
 
 vars = {"u_phase_avg", "v_phase_avg", "w_phase_avg", "y", "z",...
         "num_bins", "U", "U_act"};
 
 load(filepath, vars{:})
 
-y = squeeze(y(3,:,:));
-z = squeeze(z(3,:,:));
+y = squeeze(y(SOURCE_X_INDEX,:,:));
+z = squeeze(z(SOURCE_X_INDEX,:,:));
 
 y_idx = find(y(:,1) > TRIM_Y_BOUNDS(1) & y(:,1) < TRIM_Y_BOUNDS(2));
 z_idx = find(z(1,:) > TRIM_Z_BOUNDS(1) & z(1,:) < TRIM_Z_BOUNDS(2));
 
-u_phase_avg = squeeze(u_phase_avg(3,y_idx,z_idx,:));
-v_phase_avg = squeeze(v_phase_avg(3,y_idx,z_idx,:));
-w_phase_avg = squeeze(w_phase_avg(3,y_idx,z_idx,:));
+u_phase_avg = squeeze(u_phase_avg(SOURCE_X_INDEX,y_idx,z_idx,:));
+v_phase_avg = squeeze(v_phase_avg(SOURCE_X_INDEX,y_idx,z_idx,:));
+w_phase_avg = squeeze(w_phase_avg(SOURCE_X_INDEX,y_idx,z_idx,:));
 y = y(y_idx,z_idx);
 z = z(y_idx,z_idx);
 
 speed = U_act * U;
 % [~, ~, freq] = parse_name(D.PIV_case_name);
 freq = 6;
-dt = 1 / (freq * num_bins);
+phase_dt = 1 / (freq * num_bins);
 x = zeros(1, num_bins);
 for k = 1:num_bins
-    x(k) =  speed * dt * (k - 1);
+    x(k) =  speed * phase_dt * (k - 1);
+end
+
+x_axis = x(:);
+y_axis = y(:,1);
+z_axis = z(1,:).';
+
+[y_axis, y_sort_idx] = sort(y_axis);
+[z_axis, z_sort_idx] = sort(z_axis);
+[x_axis, x_sort_idx] = sort(x_axis);
+
+u_phase_avg = u_phase_avg(y_sort_idx,z_sort_idx,x_sort_idx);
+v_phase_avg = v_phase_avg(y_sort_idx,z_sort_idx,x_sort_idx);
+w_phase_avg = w_phase_avg(y_sort_idx,z_sort_idx,x_sort_idx);
+
+is_inside_volume = @(x_query, y_query, z_query) isfinite(x_query) & ...
+    isfinite(y_query) & isfinite(z_query) & ...
+    x_query >= min(x_axis) & x_query <= max(x_axis) & ...
+    y_query >= min(y_axis) & y_query <= max(y_axis) & ...
+    z_query >= min(z_axis) & z_query <= max(z_axis);
+
+[particle_y0, particle_z0, particle_x0] = ndgrid(y_axis, z_axis, x_axis);
+grid_size = size(particle_x0);
+num_particles = numel(particle_x0);
+num_track_steps = num_particle_timesteps + 1;
+
+particle_path_x = NaN(num_particles, num_track_steps);
+particle_path_y = NaN(num_particles, num_track_steps);
+particle_path_z = NaN(num_particles, num_track_steps);
+
+particle_path_x(:,1) = particle_x0(:);
+particle_path_y(:,1) = particle_y0(:);
+particle_path_z(:,1) = particle_z0(:);
+
+cur_x = particle_path_x(:,1);
+cur_y = particle_path_y(:,1);
+cur_z = particle_path_z(:,1);
+
+for step_idx = 1:num_particle_timesteps
+    valid_particles = is_inside_volume(cur_x, cur_y, cur_z);
+
+    [k1_x, k1_y, k1_z] = sample_velocity_trilinear(cur_x, cur_y, cur_z, ...
+        x_axis, y_axis, z_axis, u_phase_avg, v_phase_avg, w_phase_avg);
+
+    [k2_x, k2_y, k2_z] = sample_velocity_trilinear(cur_x + 0.5 * particle_dt * k1_x, ...
+        cur_y + 0.5 * particle_dt * k1_y, cur_z + 0.5 * particle_dt * k1_z, ...
+        x_axis, y_axis, z_axis, u_phase_avg, v_phase_avg, w_phase_avg);
+
+    [k3_x, k3_y, k3_z] = sample_velocity_trilinear(cur_x + 0.5 * particle_dt * k2_x, ...
+        cur_y + 0.5 * particle_dt * k2_y, cur_z + 0.5 * particle_dt * k2_z, ...
+        x_axis, y_axis, z_axis, u_phase_avg, v_phase_avg, w_phase_avg);
+
+    [k4_x, k4_y, k4_z] = sample_velocity_trilinear(cur_x + particle_dt * k3_x, ...
+        cur_y + particle_dt * k3_y, cur_z + particle_dt * k3_z, ...
+        x_axis, y_axis, z_axis, u_phase_avg, v_phase_avg, w_phase_avg);
+
+    next_x = cur_x + (particle_dt / 6) * (k1_x + 2 * k2_x + 2 * k3_x + k4_x);
+    next_y = cur_y + (particle_dt / 6) * (k1_y + 2 * k2_y + 2 * k3_y + k4_y);
+    next_z = cur_z + (particle_dt / 6) * (k1_z + 2 * k2_z + 2 * k3_z + k4_z);
+
+    valid_particles = valid_particles & isfinite(next_x) & isfinite(next_y) & isfinite(next_z) & ...
+        is_inside_volume(next_x, next_y, next_z);
+
+    cur_x(:) = NaN;
+    cur_y(:) = NaN;
+    cur_z(:) = NaN;
+    cur_x(valid_particles) = next_x(valid_particles);
+    cur_y(valid_particles) = next_y(valid_particles);
+    cur_z(valid_particles) = next_z(valid_particles);
+
+    particle_path_x(:,step_idx + 1) = cur_x;
+    particle_path_y(:,step_idx + 1) = cur_y;
+    particle_path_z(:,step_idx + 1) = cur_z;
+end
+
+if plot_particle_tracks
+    plot_y_idx = 1:max(1, plot_seed_stride(1)):grid_size(1);
+    plot_z_idx = 1:max(1, plot_seed_stride(2)):grid_size(2);
+    plot_x_idx = 1:max(1, plot_seed_stride(3)):grid_size(3);
+    [plot_y_grid, plot_z_grid, plot_x_grid] = ndgrid(plot_y_idx, plot_z_idx, plot_x_idx);
+    plot_particle_idx = sub2ind(grid_size, plot_y_grid(:), plot_z_grid(:), plot_x_grid(:));
+
+    figure
+    hold on
+    grid on
+    axis equal
+    view(3)
+    xlabel("x")
+    ylabel("y")
+    zlabel("z")
+    title("RK4 particle tracks through phase-averaged velocity field")
+
+    for i = 1:numel(plot_particle_idx)
+        particle_idx = plot_particle_idx(i);
+        valid_track = isfinite(particle_path_x(particle_idx,:)) & ...
+            isfinite(particle_path_y(particle_idx,:)) & ...
+            isfinite(particle_path_z(particle_idx,:));
+        if nnz(valid_track) > 1
+            plot3(particle_path_x(particle_idx,valid_track), ...
+                particle_path_y(particle_idx,valid_track), ...
+                particle_path_z(particle_idx,valid_track), 'LineWidth', 0.75)
+        end
+    end
+
+    xlim([min(x_axis) max(x_axis)])
+    ylim([min(y_axis) max(y_axis)])
+    zlim([min(z_axis) max(z_axis)])
 end

--- a/Calimero/Flow Visualization/FTLE_test.m
+++ b/Calimero/Flow Visualization/FTLE_test.m
@@ -11,9 +11,6 @@ particle_dt = (1 / 6) / 125;
 num_particle_timesteps = 125;
 plot_seed_stride = [4 4 8]; % [y z x] stride used only for plotting
 plot_particle_tracks = true;
-if strcmp(getenv("FTLE_DISABLE_PARTICLE_PLOT"), "1")
-    plot_particle_tracks = false;
-end
 
 vars = {"u_phase_avg", "v_phase_avg", "w_phase_avg", "y", "z",...
         "num_bins", "U", "U_act"};

--- a/Calimero/Flow Visualization/FTLE_test.m
+++ b/Calimero/Flow Visualization/FTLE_test.m
@@ -98,8 +98,7 @@ for step_idx = 1:num_particle_timesteps
     next_y = cur_y + (particle_dt / 6) * (k1_y + 2 * k2_y + 2 * k3_y + k4_y);
     next_z = cur_z + (particle_dt / 6) * (k1_z + 2 * k2_z + 2 * k3_z + k4_z);
 
-    valid_particles = valid_particles & isfinite(next_x) & isfinite(next_y) & isfinite(next_z) & ...
-        is_inside_volume(next_x, next_y, next_z);
+    valid_particles = valid_particles & is_inside_volume(next_x, next_y, next_z);
 
     cur_x(:) = NaN;
     cur_y(:) = NaN;

--- a/Calimero/Flow Visualization/sample_velocity_trilinear.m
+++ b/Calimero/Flow Visualization/sample_velocity_trilinear.m
@@ -1,3 +1,7 @@
+% Inputs: x_query/y_query/z_query are particle locations to sample; x_axis,
+% y_axis, and z_axis define the rectilinear grid; u_field/v_field/w_field
+% are velocity components stored as (y, z, x). Outputs: u_query, v_query,
+% and w_query are interpolated velocities with NaN for out-of-bounds points.
 function [u_query, v_query, w_query] = sample_velocity_trilinear(x_query, y_query, z_query, ...
     x_axis, y_axis, z_axis, u_field, v_field, w_field)
 
@@ -43,6 +47,9 @@ v_query = reshape(v_query, query_size);
 w_query = reshape(w_query, query_size);
 end
 
+% Inputs: axis_values is one sorted grid axis and query_values are locations
+% on that axis. Outputs: idx gives the lower cell index and weight gives
+% each query's normalized distance from idx to idx + 1.
 function [idx, weight] = get_axis_cell(axis_values, query_values)
 idx = interp1(axis_values, 1:numel(axis_values), query_values, 'previous', NaN);
 idx = max(1, min(numel(axis_values) - 1, idx));
@@ -50,6 +57,9 @@ next_idx = idx + 1;
 weight = (query_values - axis_values(idx)) ./ (axis_values(next_idx) - axis_values(idx));
 end
 
+% Inputs: field is one velocity component stored as (y, z, x); y_idx/z_idx/
+% x_idx identify the lower cell corner; y_weight/z_weight/x_weight are
+% trilinear interpolation weights. Output: values are interpolated samples.
 function values = interpolate_component(field, y_idx, z_idx, x_idx, y_weight, z_weight, x_weight)
 field_size = size(field);
 

--- a/Calimero/Flow Visualization/sample_velocity_trilinear.m
+++ b/Calimero/Flow Visualization/sample_velocity_trilinear.m
@@ -1,0 +1,74 @@
+function [u_query, v_query, w_query] = sample_velocity_trilinear(x_query, y_query, z_query, ...
+    x_axis, y_axis, z_axis, u_field, v_field, w_field)
+
+query_size = size(x_query);
+x_query = x_query(:);
+y_query = y_query(:);
+z_query = z_query(:);
+
+u_query = NaN(size(x_query));
+v_query = NaN(size(x_query));
+w_query = NaN(size(x_query));
+
+x_axis = x_axis(:);
+y_axis = y_axis(:);
+z_axis = z_axis(:);
+
+in_bounds = isfinite(x_query) & isfinite(y_query) & isfinite(z_query) & ...
+    x_query >= x_axis(1) & x_query <= x_axis(end) & ...
+    y_query >= y_axis(1) & y_query <= y_axis(end) & ...
+    z_query >= z_axis(1) & z_query <= z_axis(end);
+
+if ~any(in_bounds)
+    u_query = reshape(u_query, query_size);
+    v_query = reshape(v_query, query_size);
+    w_query = reshape(w_query, query_size);
+    return
+end
+
+valid_idx = find(in_bounds);
+[x_idx, x_weight] = get_axis_cell(x_axis, x_query(valid_idx));
+[y_idx, y_weight] = get_axis_cell(y_axis, y_query(valid_idx));
+[z_idx, z_weight] = get_axis_cell(z_axis, z_query(valid_idx));
+
+u_query(valid_idx) = interpolate_component(u_field, y_idx, z_idx, x_idx, ...
+    y_weight, z_weight, x_weight);
+v_query(valid_idx) = interpolate_component(v_field, y_idx, z_idx, x_idx, ...
+    y_weight, z_weight, x_weight);
+w_query(valid_idx) = interpolate_component(w_field, y_idx, z_idx, x_idx, ...
+    y_weight, z_weight, x_weight);
+
+u_query = reshape(u_query, query_size);
+v_query = reshape(v_query, query_size);
+w_query = reshape(w_query, query_size);
+end
+
+function [idx, weight] = get_axis_cell(axis_values, query_values)
+idx = interp1(axis_values, 1:numel(axis_values), query_values, 'previous', NaN);
+idx = max(1, min(numel(axis_values) - 1, idx));
+next_idx = idx + 1;
+weight = (query_values - axis_values(idx)) ./ (axis_values(next_idx) - axis_values(idx));
+end
+
+function values = interpolate_component(field, y_idx, z_idx, x_idx, y_weight, z_weight, x_weight)
+field_size = size(field);
+
+c000 = field(sub2ind(field_size, y_idx,     z_idx,     x_idx));
+c100 = field(sub2ind(field_size, y_idx + 1, z_idx,     x_idx));
+c010 = field(sub2ind(field_size, y_idx,     z_idx + 1, x_idx));
+c110 = field(sub2ind(field_size, y_idx + 1, z_idx + 1, x_idx));
+c001 = field(sub2ind(field_size, y_idx,     z_idx,     x_idx + 1));
+c101 = field(sub2ind(field_size, y_idx + 1, z_idx,     x_idx + 1));
+c011 = field(sub2ind(field_size, y_idx,     z_idx + 1, x_idx + 1));
+c111 = field(sub2ind(field_size, y_idx + 1, z_idx + 1, x_idx + 1));
+
+c00 = c000 .* (1 - y_weight) + c100 .* y_weight;
+c10 = c010 .* (1 - y_weight) + c110 .* y_weight;
+c01 = c001 .* (1 - y_weight) + c101 .* y_weight;
+c11 = c011 .* (1 - y_weight) + c111 .* y_weight;
+
+c0 = c00 .* (1 - z_weight) + c10 .* z_weight;
+c1 = c01 .* (1 - z_weight) + c11 .* z_weight;
+
+values = c0 .* (1 - x_weight) + c1 .* x_weight;
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Adds RK4 particle advection in `FTLE_test.m` using one seed per velocity-grid point.
- Stores particle trajectories and marks particles as `NaN` after they leave the interpolated volume.
- Adds strided 3D trajectory plotting and a vectorized trilinear velocity interpolation helper.
- Removes the unused `FTLE_DISABLE_PARTICLE_PLOT` environment override; plotting is controlled by the editable `plot_particle_tracks` variable.

### Testing
- `git diff --check`
- `octave --no-gui --quiet --eval <trilinear interpolation helper accuracy test>`
- `octave --no-gui --quiet --eval <synthetic RK4 and plotting smoke test>`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36a3bcd7-2b27-4836-836c-0a197d1cc8d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36a3bcd7-2b27-4836-836c-0a197d1cc8d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

