### PR TITLE
Add FTLE finite-difference isosurfaces

### DIFF
--- a/Calimero/Flow Visualization/FTLE_test.m
+++ b/Calimero/Flow Visualization/FTLE_test.m
@@ -9,8 +9,13 @@ SOURCE_X_INDEX = 3;
 
 particle_dt = (1 / 6) / 125;
 num_particle_timesteps = 50;
+total_step_time = num_particle_timesteps * particle_dt;
+particle_seed_stride = [2 2 2]; % [y z x] spacing for FTLE finite differences
 plot_seed_stride = [4 4 8]; % [y z x] stride used only for plotting
 plot_particle_tracks = true;
+plot_ftle_isosurfaces = true;
+ftle_iso_percentiles = [75 90];
+ftle_face_alpha = 0.45;
 
 vars = {"u_phase_avg", "v_phase_avg", "w_phase_avg", "y", "z",...
         "num_bins", "U", "U_act", "L"};
@@ -62,8 +67,12 @@ is_inside_volume = @(x_query, y_query, z_query) isfinite(x_query) & ...
     y_query >= min(y_axis) & y_query <= max(y_axis) & ...
     z_query >= min(z_axis) & z_query <= max(z_axis);
 
-% sample particles at every other grid point
-[particle_y0, particle_z0, particle_x0] = ndgrid(y_axis(1:2:end), z_axis(1:2:end), x_axis(1:2:end));
+% sample particles on a regular lattice so neighboring tracks define the
+% central finite differences used for the FTLE flow-map Jacobian
+[particle_y0, particle_z0, particle_x0] = ndgrid( ...
+    y_axis(1:particle_seed_stride(1):end), ...
+    z_axis(1:particle_seed_stride(2):end), ...
+    x_axis(1:particle_seed_stride(3):end));
 grid_size = size(particle_x0);
 num_particles = numel(particle_x0);
 num_track_steps = num_particle_timesteps + 1;
@@ -120,6 +129,14 @@ for step_idx = 1:num_particle_timesteps
     end
 end
 
+particle_final_x = reshape(particle_path_x(:,end), grid_size);
+particle_final_y = reshape(particle_path_y(:,end), grid_size);
+particle_final_z = reshape(particle_path_z(:,end), grid_size);
+
+[ftle_scalar, ftle_max_eigenvalue] = compute_ftle_from_flow_map( ...
+    particle_x0, particle_y0, particle_z0, ...
+    particle_final_x, particle_final_y, particle_final_z, total_step_time);
+
 if plot_particle_tracks
     plot_y_idx = 1:max(1, plot_seed_stride(1)):grid_size(1);
     plot_z_idx = 1:max(1, plot_seed_stride(2)):grid_size(2);
@@ -152,4 +169,89 @@ if plot_particle_tracks
     xlim([min(x_axis) max(x_axis)])
     ylim([min(y_axis) max(y_axis)])
     zlim([min(z_axis) max(z_axis)])
+end
+
+if plot_ftle_isosurfaces
+    plot_ftle_volume_isosurfaces(particle_x0, particle_y0, particle_z0, ...
+        ftle_scalar, ftle_iso_percentiles, ftle_face_alpha, total_step_time)
+end
+
+function plot_ftle_volume_isosurfaces(particle_x0, particle_y0, particle_z0, ...
+    ftle_scalar, ftle_iso_percentiles, ftle_face_alpha, total_step_time)
+
+particle_y_axis = squeeze(particle_y0(:,1,1));
+particle_z_axis = squeeze(particle_z0(1,:,1));
+particle_x_axis = squeeze(particle_x0(1,1,:));
+
+% meshgrid ordering is (y, x, z), while the FTLE field is stored as (y, z, x).
+[X_ftle, Y_ftle, Z_ftle] = meshgrid(particle_x_axis, particle_y_axis, particle_z_axis);
+ftle_plot = permute(ftle_scalar, [1 3 2]);
+valid_ftle = ftle_plot(isfinite(ftle_plot));
+
+if isempty(valid_ftle)
+    warning("No valid FTLE values were available for isosurface plotting.")
+    return
+end
+
+iso_values = percentile_values(valid_ftle, ftle_iso_percentiles);
+iso_values = unique(iso_values(isfinite(iso_values)));
+iso_values = iso_values(iso_values > min(valid_ftle) & iso_values < max(valid_ftle));
+
+if isempty(iso_values)
+    warning("FTLE isosurface levels were outside the valid scalar-field range.")
+    return
+end
+
+figure
+ax = gca;
+hold(ax, "on")
+grid(ax, "on")
+axis(ax, "equal")
+view(ax, 3)
+xlabel(ax, "x")
+ylabel(ax, "y")
+zlabel(ax, "z")
+title(ax, sprintf("FTLE isosurfaces, T = %.4g s", total_step_time))
+
+colors = lines(numel(iso_values));
+for iso_idx = 1:numel(iso_values)
+    iso_value = iso_values(iso_idx);
+    surface_data = isosurface(X_ftle, Y_ftle, Z_ftle, ftle_plot, iso_value);
+    if isempty(surface_data.vertices) || isempty(surface_data.faces)
+        continue
+    end
+
+    surface_patch = patch(ax, "Faces", surface_data.faces, ...
+        "Vertices", surface_data.vertices);
+    surface_patch.FaceColor = colors(iso_idx,:);
+    surface_patch.EdgeColor = "none";
+    surface_patch.FaceAlpha = ftle_face_alpha;
+    surface_patch.DisplayName = sprintf("FTLE = %.4g", iso_value);
+    isonormals(X_ftle, Y_ftle, Z_ftle, ftle_plot, surface_patch)
+end
+
+legend(ax, "show", "Location", "best")
+camlight(ax, "headlight")
+lighting(ax, "gouraud")
+xlim(ax, [min(particle_x_axis) max(particle_x_axis)])
+ylim(ax, [min(particle_y_axis) max(particle_y_axis)])
+zlim(ax, [min(particle_z_axis) max(particle_z_axis)])
+end
+
+function values = percentile_values(data, percentiles)
+data = sort(data(:));
+percentiles = min(100, max(0, percentiles(:)));
+
+if isempty(data)
+    values = NaN(size(percentiles));
+    return
+end
+
+rank = 1 + (percentiles / 100) * (numel(data) - 1);
+lower_idx = floor(rank);
+upper_idx = ceil(rank);
+weight = rank - lower_idx;
+
+values = data(lower_idx) .* (1 - weight) + data(upper_idx) .* weight;
+values = reshape(values, size(percentiles));
 end

--- a/Calimero/Flow Visualization/compute_ftle_from_flow_map.m
+++ b/Calimero/Flow Visualization/compute_ftle_from_flow_map.m
@@ -1,0 +1,95 @@
+function [ftle_scalar, max_eigenvalue] = compute_ftle_from_flow_map( ...
+    initial_x, initial_y, initial_z, final_x, final_y, final_z, total_step_time)
+%COMPUTE_FTLE_FROM_FLOW_MAP Calculate FTLE from an initial/final flow map.
+% Initial and final coordinates are stored on a regular particle lattice with
+% dimensions (y, z, x). The returned fields use the same ordering.
+
+if total_step_time <= 0 || ~isfinite(total_step_time)
+    error("total_step_time must be a positive finite scalar.")
+end
+
+grid_size = array_size_3d(initial_x);
+if ~isequal(grid_size, array_size_3d(initial_y), array_size_3d(initial_z), ...
+        array_size_3d(final_x), array_size_3d(final_y), array_size_3d(final_z))
+    error("Initial and final particle-coordinate arrays must have matching sizes.")
+end
+
+ftle_scalar = NaN(grid_size);
+max_eigenvalue = NaN(grid_size);
+
+if any(grid_size < 3)
+    return
+end
+
+interior_y = 2:(grid_size(1) - 1);
+interior_z = 2:(grid_size(2) - 1);
+interior_x = 2:(grid_size(3) - 1);
+
+dx0 = initial_x(interior_y,interior_z,interior_x + 1) - ...
+    initial_x(interior_y,interior_z,interior_x - 1);
+dy0 = initial_y(interior_y + 1,interior_z,interior_x) - ...
+    initial_y(interior_y - 1,interior_z,interior_x);
+dz0 = initial_z(interior_y,interior_z + 1,interior_x) - ...
+    initial_z(interior_y,interior_z - 1,interior_x);
+
+dxdx0 = central_difference(final_x, interior_y, interior_z, interior_x, 3, dx0);
+dxdy0 = central_difference(final_x, interior_y, interior_z, interior_x, 1, dy0);
+dxdz0 = central_difference(final_x, interior_y, interior_z, interior_x, 2, dz0);
+
+dydx0 = central_difference(final_y, interior_y, interior_z, interior_x, 3, dx0);
+dydy0 = central_difference(final_y, interior_y, interior_z, interior_x, 1, dy0);
+dydz0 = central_difference(final_y, interior_y, interior_z, interior_x, 2, dz0);
+
+dzdx0 = central_difference(final_z, interior_y, interior_z, interior_x, 3, dx0);
+dzdy0 = central_difference(final_z, interior_y, interior_z, interior_x, 1, dy0);
+dzdz0 = central_difference(final_z, interior_y, interior_z, interior_x, 2, dz0);
+
+valid_gradient = isfinite(dxdx0) & isfinite(dxdy0) & isfinite(dxdz0) & ...
+    isfinite(dydx0) & isfinite(dydy0) & isfinite(dydz0) & ...
+    isfinite(dzdx0) & isfinite(dzdy0) & isfinite(dzdz0);
+
+valid_idx = find(valid_gradient);
+for idx = valid_idx(:).'
+    jacobian = [dxdx0(idx), dxdy0(idx), dxdz0(idx); ...
+                dydx0(idx), dydy0(idx), dydz0(idx); ...
+                dzdx0(idx), dzdy0(idx), dzdz0(idx)];
+    cauchy_green = jacobian.' * jacobian;
+    lambda_max = max(real(eig(cauchy_green)));
+
+    if lambda_max > 0 && isfinite(lambda_max)
+        [local_y, local_z, local_x] = ind2sub(size(valid_gradient), idx);
+        field_y = local_y + 1;
+        field_z = local_z + 1;
+        field_x = local_x + 1;
+
+        max_eigenvalue(field_y,field_z,field_x) = lambda_max;
+        ftle_scalar(field_y,field_z,field_x) = log(lambda_max) / (2 * total_step_time);
+    end
+end
+end
+
+function derivative = central_difference(field, interior_y, interior_z, interior_x, dimension, denominator)
+switch dimension
+    case 1
+        numerator = field(interior_y + 1,interior_z,interior_x) - ...
+            field(interior_y - 1,interior_z,interior_x);
+    case 2
+        numerator = field(interior_y,interior_z + 1,interior_x) - ...
+            field(interior_y,interior_z - 1,interior_x);
+    case 3
+        numerator = field(interior_y,interior_z,interior_x + 1) - ...
+            field(interior_y,interior_z,interior_x - 1);
+    otherwise
+        error("dimension must be 1, 2, or 3.")
+end
+
+derivative = numerator ./ denominator;
+derivative(~isfinite(derivative)) = NaN;
+end
+
+function grid_size = array_size_3d(array)
+grid_size = size(array);
+if numel(grid_size) < 3
+    grid_size(3) = 1;
+end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Compute `total_step_time` for particle advection and retain a regular seed lattice for central finite differences.
- Add `compute_ftle_from_flow_map` to form the flow-map Jacobian, Cauchy-Green deformation tensor, maximum eigenvalue, and FTLE scalar field.
- Plot 3D FTLE isosurfaces at configurable scalar-field percentiles.

### Testing
- `git diff --check HEAD~1..HEAD`
- `python3` independent synthetic central-difference FTLE calculation
- `python3` source assertions for timestep, Cauchy-Green/eigenvalue formula, FTLE formula, and isosurface plotting path
- `matlab -batch ...` could not run because MATLAB is not installed on this VM
- `octave --eval ...` could not run because Octave is not installed on this VM
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a638b8f-4055-4696-bc46-f223a58e72d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a638b8f-4055-4696-bc46-f223a58e72d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

