### PR TITLE
Wrap FTLE particle tracks in periodic x

### DIFF
--- a/Calimero/Flow Visualization/FTLE_test.m
+++ b/Calimero/Flow Visualization/FTLE_test.m
@@ -61,9 +61,11 @@ u_phase_avg = u_phase_avg(y_sort_idx,z_sort_idx,x_sort_idx);
 v_phase_avg = v_phase_avg(y_sort_idx,z_sort_idx,x_sort_idx);
 w_phase_avg = w_phase_avg(y_sort_idx,z_sort_idx,x_sort_idx);
 
+x_bounds = [min(x_axis), max(x_axis)];
+wrap_x_periodic = @(x_query) wrap_periodic_coordinate(x_query, x_bounds(1), x_bounds(2));
+
 is_inside_volume = @(x_query, y_query, z_query) isfinite(x_query) & ...
     isfinite(y_query) & isfinite(z_query) & ...
-    x_query >= min(x_axis) & x_query <= max(x_axis) & ...
     y_query >= min(y_axis) & y_query <= max(y_axis) & ...
     z_query >= min(z_axis) & z_query <= max(z_axis);
 
@@ -92,22 +94,26 @@ cur_z = particle_path_z(:,1);
 for step_idx = 1:num_particle_timesteps
     valid_particles = is_inside_volume(cur_x, cur_y, cur_z);
 
-    [k1_x, k1_y, k1_z] = sample_velocity_trilinear(cur_x, cur_y, cur_z, ...
+    [k1_x, k1_y, k1_z] = sample_velocity_trilinear(wrap_x_periodic(cur_x), cur_y, cur_z, ...
         x_axis, y_axis, z_axis, u_phase_avg, v_phase_avg, w_phase_avg);
 
-    [k2_x, k2_y, k2_z] = sample_velocity_trilinear(cur_x + 0.5 * particle_dt * k1_x, ...
+    k2_sample_x = wrap_x_periodic(cur_x + 0.5 * particle_dt * k1_x);
+    [k2_x, k2_y, k2_z] = sample_velocity_trilinear(k2_sample_x, ...
         cur_y + 0.5 * particle_dt * k1_y, cur_z + 0.5 * particle_dt * k1_z, ...
         x_axis, y_axis, z_axis, u_phase_avg, v_phase_avg, w_phase_avg);
 
-    [k3_x, k3_y, k3_z] = sample_velocity_trilinear(cur_x + 0.5 * particle_dt * k2_x, ...
+    k3_sample_x = wrap_x_periodic(cur_x + 0.5 * particle_dt * k2_x);
+    [k3_x, k3_y, k3_z] = sample_velocity_trilinear(k3_sample_x, ...
         cur_y + 0.5 * particle_dt * k2_y, cur_z + 0.5 * particle_dt * k2_z, ...
         x_axis, y_axis, z_axis, u_phase_avg, v_phase_avg, w_phase_avg);
 
-    [k4_x, k4_y, k4_z] = sample_velocity_trilinear(cur_x + particle_dt * k3_x, ...
+    k4_sample_x = wrap_x_periodic(cur_x + particle_dt * k3_x);
+    [k4_x, k4_y, k4_z] = sample_velocity_trilinear(k4_sample_x, ...
         cur_y + particle_dt * k3_y, cur_z + particle_dt * k3_z, ...
         x_axis, y_axis, z_axis, u_phase_avg, v_phase_avg, w_phase_avg);
 
-    next_x = cur_x + (particle_dt / 6) * (k1_x + 2 * k2_x + 2 * k3_x + k4_x);
+    next_x = wrap_x_periodic(cur_x + (particle_dt / 6) * ...
+        (k1_x + 2 * k2_x + 2 * k3_x + k4_x));
     next_y = cur_y + (particle_dt / 6) * (k1_y + 2 * k2_y + 2 * k3_y + k4_y);
     next_z = cur_z + (particle_dt / 6) * (k1_z + 2 * k2_z + 2 * k3_z + k4_z);
 
@@ -254,4 +260,16 @@ weight = rank - lower_idx;
 
 values = data(lower_idx) .* (1 - weight) + data(upper_idx) .* weight;
 values = reshape(values, size(percentiles));
+end
+
+function wrapped = wrap_periodic_coordinate(query, lower_bound, upper_bound)
+wrapped = query;
+period = upper_bound - lower_bound;
+
+if period <= 0 || ~isfinite(period)
+    return
+end
+
+outside = isfinite(query) & (query < lower_bound | query > upper_bound);
+wrapped(outside) = lower_bound + mod(query(outside) - lower_bound, period);
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Treat x as periodic for FTLE particle advection while preserving NaN invalidation for y/z exits.
- Wrap RK4 intermediate x sample locations and final particle x positions back into the sampled x interval.

### Testing
- Passed: `git diff --check HEAD~1 HEAD`
- Passed: `python3 -c 'import math; wrap=lambda vals,lo,hi:[lo+((v-lo)%(hi-lo)) if math.isfinite(v) and (v<lo or v>hi) else v for v in vals]; w=wrap([0.0,10.0,10.25,-0.5,25.0,math.nan],0.0,10.0); assert w[:5]==[0.0,10.0,0.25,9.5,5.0] and math.isnan(w[5]); valid=[math.isfinite(x) and math.isfinite(y) and math.isfinite(z) and -1.0<=y<=1.0 and -1.0<=z<=1.0 for x,y,z in zip(w,[0,0,0,0,2,0],[0,3,0,0,0,0])]; assert valid==[True,False,True,True,False,False]; print(w); print(valid)'`
- Warning: MATLAB/Octave runtime is unavailable on this VM (`octave unavailable`, `matlab unavailable`), so the full `.m` script could not be executed end-to-end here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c05a481-3ae1-4cbd-bc9b-ca785e703ea1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c05a481-3ae1-4cbd-bc9b-ca785e703ea1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

